### PR TITLE
ListView enhancements

### DIFF
--- a/Nodes/UI.Listview Data.dyf
+++ b/Nodes/UI.Listview Data.dyf
@@ -43,8 +43,6 @@ class listview():
 
     def __repr__(self):
         return 'UI.ListView input'
-        
-x = listview(IN[0],IN[3],IN[4],IN[5],IN[6],IN[7])
 
 if isinstance(IN[1],list):
 	in1 = IN[1]
@@ -56,12 +54,18 @@ if isinstance(IN[2],list):
 else:
 	in2 = [IN[2]]
 
+if IN[6]:
+	element_count = len(in1)
+else:
+	element_count = 0
+
+x = listview(IN[0],IN[3],IN[4],IN[5],element_count,IN[7])
+
 for k,v in zip(in1,in2):
 	try:
 		x[str(k)] = v
 	except:
 		x[k.encode('utf-8').decode('utf-8')] = v
-
 
 OUT = x</Script>
     </PythonNodeModels.PythonNode>

--- a/Nodes/UI.Listview Data.dyf
+++ b/Nodes/UI.Listview Data.dyf
@@ -1,7 +1,10 @@
-<Workspace Version="1.3.0.875" X="216.6468" Y="-216.0851375" zoom="1.33823125" ScaleFactor="1" Name="UI.Listview Data" Description="Create data for ListView input in UI.MultiInputForm ++ . Check out www.data-shapes.net for more infos." ID="c3a36eb7-8fe8-4417-b31e-ccc9fded769b" Category="Data-Shapes.UI">
-  <NamespaceResolutionMap />
+<Workspace Version="1.3.0.875" X="199.874193697156" Y="-105.894055524481" zoom="0.954042924882813" ScaleFactor="1" Name="UI.Listview Data" Description="Create data for ListView input in UI.MultiInputForm ++ . Check out www.data-shapes.net for more infos." ID="c3a36eb7-8fe8-4417-b31e-ccc9fded769b" Category="Data-Shapes.UI">
+  <NamespaceResolutionMap>
+    <ClassMap partialName="DSCore.List.Empty" resolvedName="DSCore.List" assemblyName="DSCoreNodes.dll" />
+    <ClassMap partialName="DSCore.List" resolvedName="DSCore.List" assemblyName="DSCoreNodes.dll" />
+  </NamespaceResolutionMap>
   <Elements>
-    <PythonNodeModels.PythonNode guid="cef200ad-1512-4bc5-ad03-6400d44b9b89" type="PythonNodeModels.PythonNode" nickname="Python Script" x="704" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="7">
+    <PythonNodeModels.PythonNode guid="cef200ad-1512-4bc5-ad03-6400d44b9b89" type="PythonNodeModels.PythonNode" nickname="Python Script" x="702.505489989118" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="8">
       <PortInfo index="0" default="False" />
       <PortInfo index="1" default="False" />
       <PortInfo index="2" default="False" />
@@ -9,17 +12,19 @@
       <PortInfo index="4" default="False" />
       <PortInfo index="5" default="False" />
       <PortInfo index="6" default="False" />
+      <PortInfo index="7" default="False" />
       <Script>#Copyright (c) mostafa el ayoubi ,  2016
 #Data-Shapes www.data-shapes.net , elayoubi.mostafa@gmail.com
 
 class listview():
 
-    def __init__(self,inputname,height,highlight,display_mode,element_count):
+    def __init__(self,inputname,height,highlight,display_mode,element_count,default_values):
         self.inputname = inputname
         self.height = height
         self.highlight = highlight
         self.display_mode = display_mode
         self.element_count = element_count
+        self.default_values = default_values
 
     def __setitem__(self, key, item):
         self.__dict__[key] = item
@@ -39,7 +44,7 @@ class listview():
     def __repr__(self):
         return 'UI.ListView input'
         
-x = listview(IN[0],IN[3],IN[4],IN[5],IN[6])
+x = listview(IN[0],IN[3],IN[4],IN[5],IN[6],IN[7])
 
 if isinstance(IN[1],list):
 	in1 = IN[1]
@@ -82,8 +87,11 @@ OUT = x</Script>
     <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="17b88acf-e454-4649-b20b-534a6db34799" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-109" y="569" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <Symbol value="// Turns off ability to select elements. Form will not output any data for this element.&#xD;&#xA;DisplayModeOnly : bool = false" />
     </Dynamo.Graph.Nodes.CustomNodes.Symbol>
-    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="08be7782-cbdb-44b5-9706-0b8e86e8ef86" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-106" y="675" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="08be7782-cbdb-44b5-9706-0b8e86e8ef86" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="34.4548962159743" y="682.337196070984" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <Symbol value="// Will display the number of elements underneath the input name&#xD;&#xA;ShowElementCount : bool = false" />
+    </Dynamo.Graph.Nodes.CustomNodes.Symbol>
+    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="3070d208-b980-42fb-82b5-5969b13d0fc0" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="186.851171247113" y="774.906156400992" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <Symbol value="DefaultValueIndices : int[] = DSCore.List.Empty" />
     </Dynamo.Graph.Nodes.CustomNodes.Symbol>
   </Elements>
   <Connectors>
@@ -95,6 +103,7 @@ OUT = x</Script>
     <Dynamo.Graph.Connectors.ConnectorModel start="163d591e-213c-4079-844e-221f0de52d14" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="4" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="17b88acf-e454-4649-b20b-534a6db34799" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="5" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="08be7782-cbdb-44b5-9706-0b8e86e8ef86" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="6" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="3070d208-b980-42fb-82b5-5969b13d0fc0" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="7" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />

--- a/Nodes/UI.Listview Data.dyf
+++ b/Nodes/UI.Listview Data.dyf
@@ -1,21 +1,23 @@
 <Workspace Version="1.3.0.875" X="195" Y="43" zoom="1" ScaleFactor="1" Name="UI.Listview Data" Description="Create data for ListView input in UI.MultiInputForm ++ . Check out www.data-shapes.net for more infos." ID="c3a36eb7-8fe8-4417-b31e-ccc9fded769b" Category="Data-Shapes.UI">
   <NamespaceResolutionMap />
   <Elements>
-    <PythonNodeModels.PythonNode guid="cef200ad-1512-4bc5-ad03-6400d44b9b89" type="PythonNodeModels.PythonNode" nickname="Python Script" x="704" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="5">
+    <PythonNodeModels.PythonNode guid="cef200ad-1512-4bc5-ad03-6400d44b9b89" type="PythonNodeModels.PythonNode" nickname="Python Script" x="704" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="6">
       <PortInfo index="0" default="False" />
       <PortInfo index="1" default="False" />
       <PortInfo index="2" default="False" />
       <PortInfo index="3" default="False" />
       <PortInfo index="4" default="False" />
+      <PortInfo index="5" default="False" />
       <Script>#Copyright (c) mostafa el ayoubi ,  2016
 #Data-Shapes www.data-shapes.net , elayoubi.mostafa@gmail.com
 
 class listview():
 
-    def __init__(self,inputname,height,highlight):
+    def __init__(self,inputname,height,highlight,display_mode):
         self.inputname = inputname
         self.height = height
         self.highlight = highlight
+        self.display_mode = display_mode
 
     def __setitem__(self, key, item):
         self.__dict__[key] = item
@@ -35,7 +37,7 @@ class listview():
     def __repr__(self):
         return 'UI.ListView input'
         
-x = listview(IN[0],IN[3],IN[4])
+x = listview(IN[0],IN[3],IN[4], IN[5])
 
 if isinstance(IN[1],list):
 	in1 = IN[1]
@@ -72,8 +74,11 @@ OUT = x</Script>
     <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="34be11ca-1a24-482f-9aa1-8ac0caf5cc65" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="362" y="375" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <Symbol value="Height : int = 200" />
     </Dynamo.Graph.Nodes.CustomNodes.Symbol>
-    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="163d591e-213c-4079-844e-221f0de52d14" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="190" y="465" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="163d591e-213c-4079-844e-221f0de52d14" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-112" y="461" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <Symbol value="// If true clicking elements of the listview will highlight it in a view like Dynamo's watch node&#xD;&#xA;HighlightInView : bool = false" />
+    </Dynamo.Graph.Nodes.CustomNodes.Symbol>
+    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="17b88acf-e454-4649-b20b-534a6db34799" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-109" y="569" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <Symbol value="// Turns off ability to select elements. Form will not output any data for this element.&#xD;&#xA;DisplayModeOnly : bool = false" />
     </Dynamo.Graph.Nodes.CustomNodes.Symbol>
   </Elements>
   <Connectors>
@@ -83,11 +88,12 @@ OUT = x</Script>
     <Dynamo.Graph.Connectors.ConnectorModel start="be4be692-c420-47f5-8bab-b966c29580f0" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="2" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="34be11ca-1a24-482f-9aa1-8ac0caf5cc65" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="3" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="163d591e-213c-4079-844e-221f0de52d14" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="4" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="17b88acf-e454-4649-b20b-534a6db34799" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="5" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+    <Camera Name="Hintergrundvorschau" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
   </Cameras>
 </Workspace>

--- a/Nodes/UI.Listview Data.dyf
+++ b/Nodes/UI.Listview Data.dyf
@@ -1,23 +1,25 @@
-<Workspace Version="1.3.0.875" X="195" Y="43" zoom="1" ScaleFactor="1" Name="UI.Listview Data" Description="Create data for ListView input in UI.MultiInputForm ++ . Check out www.data-shapes.net for more infos." ID="c3a36eb7-8fe8-4417-b31e-ccc9fded769b" Category="Data-Shapes.UI">
+<Workspace Version="1.3.0.875" X="216.6468" Y="-216.0851375" zoom="1.33823125" ScaleFactor="1" Name="UI.Listview Data" Description="Create data for ListView input in UI.MultiInputForm ++ . Check out www.data-shapes.net for more infos." ID="c3a36eb7-8fe8-4417-b31e-ccc9fded769b" Category="Data-Shapes.UI">
   <NamespaceResolutionMap />
   <Elements>
-    <PythonNodeModels.PythonNode guid="cef200ad-1512-4bc5-ad03-6400d44b9b89" type="PythonNodeModels.PythonNode" nickname="Python Script" x="704" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="6">
+    <PythonNodeModels.PythonNode guid="cef200ad-1512-4bc5-ad03-6400d44b9b89" type="PythonNodeModels.PythonNode" nickname="Python Script" x="704" y="199" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="7">
       <PortInfo index="0" default="False" />
       <PortInfo index="1" default="False" />
       <PortInfo index="2" default="False" />
       <PortInfo index="3" default="False" />
       <PortInfo index="4" default="False" />
       <PortInfo index="5" default="False" />
+      <PortInfo index="6" default="False" />
       <Script>#Copyright (c) mostafa el ayoubi ,  2016
 #Data-Shapes www.data-shapes.net , elayoubi.mostafa@gmail.com
 
 class listview():
 
-    def __init__(self,inputname,height,highlight,display_mode):
+    def __init__(self,inputname,height,highlight,display_mode,element_count):
         self.inputname = inputname
         self.height = height
         self.highlight = highlight
         self.display_mode = display_mode
+        self.element_count = element_count
 
     def __setitem__(self, key, item):
         self.__dict__[key] = item
@@ -37,7 +39,7 @@ class listview():
     def __repr__(self):
         return 'UI.ListView input'
         
-x = listview(IN[0],IN[3],IN[4], IN[5])
+x = listview(IN[0],IN[3],IN[4],IN[5],IN[6])
 
 if isinstance(IN[1],list):
 	in1 = IN[1]
@@ -80,6 +82,9 @@ OUT = x</Script>
     <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="17b88acf-e454-4649-b20b-534a6db34799" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-109" y="569" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <Symbol value="// Turns off ability to select elements. Form will not output any data for this element.&#xD;&#xA;DisplayModeOnly : bool = false" />
     </Dynamo.Graph.Nodes.CustomNodes.Symbol>
+    <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="08be7782-cbdb-44b5-9706-0b8e86e8ef86" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-106" y="675" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
+      <Symbol value="// Will display the number of elements underneath the input name&#xD;&#xA;ShowElementCount : bool = false" />
+    </Dynamo.Graph.Nodes.CustomNodes.Symbol>
   </Elements>
   <Connectors>
     <Dynamo.Graph.Connectors.ConnectorModel start="cef200ad-1512-4bc5-ad03-6400d44b9b89" start_index="0" end="ab104914-28ac-4b9f-bcae-0fce01efb435" end_index="0" portType="0" />
@@ -89,6 +94,7 @@ OUT = x</Script>
     <Dynamo.Graph.Connectors.ConnectorModel start="34be11ca-1a24-482f-9aa1-8ac0caf5cc65" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="3" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="163d591e-213c-4079-844e-221f0de52d14" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="4" portType="0" />
     <Dynamo.Graph.Connectors.ConnectorModel start="17b88acf-e454-4649-b20b-534a6db34799" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="5" portType="0" />
+    <Dynamo.Graph.Connectors.ConnectorModel start="08be7782-cbdb-44b5-9706-0b8e86e8ef86" start_index="0" end="cef200ad-1512-4bc5-ad03-6400d44b9b89" end_index="6" portType="0" />
   </Connectors>
   <Notes />
   <Annotations />

--- a/Nodes/UI.MultipleInputForm ++.dyf
+++ b/Nodes/UI.MultipleInputForm ++.dyf
@@ -1,7 +1,7 @@
 <Workspace Version="1.3.0.875" X="374.10733387877" Y="133.008850349299" zoom="1.07925372895184" ScaleFactor="1" Name="UI.MultipleInputForm ++" Description="Create a form with multiple inputs. &#xD;&#xA;see www.data-shapes.net for tutorials and infos!" ID="9fbd05c0-ec1f-4bd3-bf37-969a1552eab8" Category="Data-Shapes.UI">
   <NamespaceResolutionMap />
   <Elements>
-    <PythonNodeModels.PythonNode guid="652ef6e6-fd19-4bd6-a3c0-f96e7445d3e4" type="PythonNodeModels.PythonNode" nickname="Python Script" x="196.684721407928" y="76.7335245748186" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="7">
+    <PythonNodeModels.PythonNode guid="652ef6e6-fd19-4bd6-a3c0-f96e7445d3e4" type="PythonNodeModels.PythonNode" nickname="Python Script" x="196.684721407928" y="77.6600907502917" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="7">
       <PortInfo index="0" default="False" />
       <PortInfo index="1" default="False" />
       <PortInfo index="2" default="False" />
@@ -367,7 +367,12 @@ try:
 		label.Location = Point(xlabel,y+4)
 		label.AutoSize = True
 		label.MaximumSize = Size(120,0)
-		label.Text = j.inputname
+		if j.__class__.__name__ == 'listview' and j.element_count:
+			# need to subtract 5 from the element counts (number of node inputs other than keys and values)
+			lv_element_count = len(j.values())-5
+			label.Text = j.inputname + '\n(' + str(lv_element_count) + ' element' + ("s" if lv_element_count != 1 else "") + ')'
+		else:
+			label.Text = j.inputname
 		form.Controls.Add(label)
 
 		if j.__class__.__name__ == 'dropdown':
@@ -399,7 +404,7 @@ try:
 				lv.CheckBoxes = True
 			lv.View = vi.Details
 			lv.Sorting = SortOrder.Ascending
-			[lv.Items.Add(i) for i in j.keys() if not (i == 'inputname' or i == 'height' or i == 'highlight' or i == 'display_mode')]
+			[lv.Items.Add(i) for i in j.keys() if not (i == 'inputname' or i == 'height' or i == 'highlight' or i == 'display_mode' or i == 'element_count')]
 			lv.Location = Point(0,0)
 			lv.Width = 160
 			lv.Height = j.height

--- a/Nodes/UI.MultipleInputForm ++.dyf
+++ b/Nodes/UI.MultipleInputForm ++.dyf
@@ -367,10 +367,8 @@ try:
 		label.Location = Point(xlabel,y+4)
 		label.AutoSize = True
 		label.MaximumSize = Size(120,0)
-		if j.__class__.__name__ == 'listview' and j.element_count:
-			# need to subtract 5 from the element counts (number of node inputs other than keys and values)
-			lv_element_count = len(j.values())-6
-			label.Text = j.inputname + '\n(' + str(lv_element_count) + ' element' + ("s" if lv_element_count != 1 else "") + ')'
+		if j.__class__.__name__ == 'listview' and j.element_count &gt; 0:
+			label.Text = j.inputname + '\n(' + str(j.element_count) + ' element' + ("s" if j.element_count &gt; 1 else "") + ')'
 		else:
 			label.Text = j.inputname
 		form.Controls.Add(label)

--- a/Nodes/UI.MultipleInputForm ++.dyf
+++ b/Nodes/UI.MultipleInputForm ++.dyf
@@ -1,4 +1,4 @@
-<Workspace Version="1.3.0.875" X="538.37196631162" Y="179.822875781361" zoom="0.931811528498333" ScaleFactor="1" Name="UI.MultipleInputForm ++" Description="Create a form with multiple inputs. &#xD;&#xA;see www.data-shapes.net for tutorials and infos!" ID="9fbd05c0-ec1f-4bd3-bf37-969a1552eab8" Category="Data-Shapes.UI">
+<Workspace Version="1.3.0.875" X="374.10733387877" Y="133.008850349299" zoom="1.07925372895184" ScaleFactor="1" Name="UI.MultipleInputForm ++" Description="Create a form with multiple inputs. &#xD;&#xA;see www.data-shapes.net for tutorials and infos!" ID="9fbd05c0-ec1f-4bd3-bf37-969a1552eab8" Category="Data-Shapes.UI">
   <NamespaceResolutionMap />
   <Elements>
     <PythonNodeModels.PythonNode guid="652ef6e6-fd19-4bd6-a3c0-f96e7445d3e4" type="PythonNodeModels.PythonNode" nickname="Python Script" x="196.684721407928" y="76.7335245748186" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="7">
@@ -395,10 +395,11 @@ try:
 			lv.HeaderStyle = ColumnHeaderStyle.None
 			lv.Columns.Add(dummyheader)
 			lv.Values = j
-			lv.CheckBoxes = True
+			if not j.display_mode:
+				lv.CheckBoxes = True
 			lv.View = vi.Details
 			lv.Sorting = SortOrder.Ascending
-			[lv.Items.Add(i) for i in j.keys() if not (i == 'inputname' or i == 'height' or i == 'highlight')]
+			[lv.Items.Add(i) for i in j.keys() if not (i == 'inputname' or i == 'height' or i == 'highlight' or i == 'display_mode')]
 			lv.Location = Point(0,0)
 			lv.Width = 160
 			lv.Height = j.height
@@ -415,22 +416,25 @@ try:
 				for item in items:
 					item.BackColor = Color.FromArgb(230,243,255)
 			#Creating select all and select none radiobuttons
-			rball = RadioButton()
-			rball.Location = Point(0,(j.height)+5)
-			rball.Width = 70
-			rball.Text = "Select all"
-			rball.Click += form.selectall
-			rbnone = RadioButton()
-			rbnone.Location = Point(80,(j.height)+5)
-			rbnone.Width = 90
-			rbnone.Text = "Select none"			
-			rbnone.Click += form.selectnone			
+			if not j.display_mode:
+				rball = RadioButton()
+				rball.Location = Point(0,(j.height)+5)
+				rball.Width = 70
+				rball.Text = "Select all"
+				rball.Click += form.selectall
+				rbnone = RadioButton()
+				rbnone.Location = Point(80,(j.height)+5)
+				rbnone.Width = 90
+				rbnone.Text = "Select none"			
+				rbnone.Click += form.selectnone			
 			#Adding controls to panel
 			lvp.Controls.Add(lv)
-			lvp.Controls.Add(rball)
-			lvp.Controls.Add(rbnone)
+			if not j.display_mode:
+				lvp.Controls.Add(rball)
+				lvp.Controls.Add(rbnone)
 			form.Controls.Add(lvp)
-			form.output.append(lv)
+			if not j.display_mode:
+				form.output.append(lv)
 			y = lvp.Bottom + 25
 		elif j.__class__.__name__ == 'uitext':
 			tb = TextBox()
@@ -816,6 +820,6 @@ except:
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Background Preview" eyeX="-12.747409590765" eyeY="43.6331654817698" eyeZ="46.4793092008243" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+    <Camera Name="Hintergrundvorschau" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
   </Cameras>
 </Workspace>

--- a/Nodes/UI.MultipleInputForm ++.dyf
+++ b/Nodes/UI.MultipleInputForm ++.dyf
@@ -369,7 +369,7 @@ try:
 		label.MaximumSize = Size(120,0)
 		if j.__class__.__name__ == 'listview' and j.element_count:
 			# need to subtract 5 from the element counts (number of node inputs other than keys and values)
-			lv_element_count = len(j.values())-5
+			lv_element_count = len(j.values())-6
 			label.Text = j.inputname + '\n(' + str(lv_element_count) + ' element' + ("s" if lv_element_count != 1 else "") + ')'
 		else:
 			label.Text = j.inputname
@@ -404,12 +404,14 @@ try:
 				lv.CheckBoxes = True
 			lv.View = vi.Details
 			lv.Sorting = SortOrder.Ascending
-			[lv.Items.Add(i) for i in j.keys() if not (i == 'inputname' or i == 'height' or i == 'highlight' or i == 'display_mode' or i == 'element_count')]
+			[lv.Items.Add(i) for i in j.keys() if not (i == 'inputname' or i == 'height' or i == 'highlight' or i == 'display_mode' or i == 'element_count' or i == 'default_values')]
 			lv.Location = Point(0,0)
 			lv.Width = 160
 			lv.Height = j.height
 			lv.Scrollable = True
 			lv.ItemCheck += form.updateallnone
+			for i in j.default_values:
+				lv.Items.Item[i].Checked = True
 			#Click listview items to hilight and center in appropriate view
 			if j.highlight :
 				lv.MouseDown += form.setviewforelement


### PR DESCRIPTION
This PR contains two enhancements for ListViews. Both can be activated separately by new boolean inputs in the ```UI.Listview Data``` node. By default, they are turned off.
1. Display mode
Changes the ListView element from an input device into an output device. Checkboxes and Select All/None controls are not displayed and the ListView does not get evaluated for the MultiInputForm output.
![listviewdisplaymode](https://cloud.githubusercontent.com/assets/3014437/25746228/c3a7364c-31a2-11e7-900f-e5127a87cdb9.PNG)
2. Optional element count
Displays an element count underneath the ListView label.
![listviewelementcount](https://cloud.githubusercontent.com/assets/3014437/25746401/8d2f35d2-31a3-11e7-81e1-671c4fb3134c.PNG)
@MostafaElAyoubi - The element count in ```UI.MultiInputForm ++``` unfortunately is slightly less elegant than I'd like it to be because we need to subtract 1 for each input of ```UI.Listview Data``` (except Keys and Values inputs). Basically that means that whenever that node gets an additional input the formula that does the element count needs to be altered. If you have a better idea for how to solve it, that'd be great.
