### PR TITLE
Fixed missing logo bug

### DIFF
--- a/Nodes/UI.MultipleInputForm ++.dyf
+++ b/Nodes/UI.MultipleInputForm ++.dyf
@@ -1,4 +1,4 @@
-<Workspace Version="1.3.0.875" X="188.10733387877" Y="169.008850349299" zoom="1.07925372895184" ScaleFactor="1" Name="UI.MultipleInputForm ++" Description="Create a form with multiple inputs. &#xD;&#xA;see www.data-shapes.net for tutorials and infos!" ID="9fbd05c0-ec1f-4bd3-bf37-969a1552eab8" Category="Data-Shapes.UI">
+<Workspace Version="1.3.0.875" X="311.74712396624" Y="193.400584759276" zoom="0.765829392851556" ScaleFactor="1" Name="UI.MultipleInputForm ++" Description="Create a form with multiple inputs. &#xD;&#xA;see www.data-shapes.net for tutorials and infos!" ID="9fbd05c0-ec1f-4bd3-bf37-969a1552eab8" Category="Data-Shapes.UI">
   <NamespaceResolutionMap />
   <Elements>
     <PythonNodeModels.PythonNode guid="652ef6e6-fd19-4bd6-a3c0-f96e7445d3e4" type="PythonNodeModels.PythonNode" nickname="Python Script" x="196.684721407928" y="77.6600907502917" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="False" IsFrozen="false" isPinned="false" inputcount="7">
@@ -17,7 +17,7 @@ try:
 	clr.AddReference('System.Windows.Forms')
 	clr.AddReference('System.Drawing')
 	
-	from System.Drawing import Point , Size , Graphics, Bitmap, Image, Font, FontStyle, Icon, Color, Region , Rectangle
+	from System.Drawing import Point , Size , Graphics, Bitmap, Image, Font, FontStyle, Icon, Color, Region , Rectangle 
 	from System.Windows.Forms import Application, DockStyle, Button, Form, Label, TrackBar , ToolTip, ColumnHeader, TextBox, CheckBox, FolderBrowserDialog, OpenFileDialog, DialogResult, ComboBox, FormBorderStyle, FormStartPosition, ListView, ListViewItem , SortOrder, Panel, ImageLayout, GroupBox, RadioButton, BorderStyle, PictureBox, PictureBoxSizeMode, LinkLabel, CheckState, ColumnHeaderStyle , ImageList
 	from System.Collections.Generic import *
 	from System.Collections.Generic import List as iList
@@ -505,8 +505,12 @@ try:
 					if rbcounter == j.defaultvalue:
 						rb.Checked = True
 					rbgroup.Controls.Add(rb)
+					g = rb.CreateGraphics()
+					sizetext = g.MeasureString(key,rb.Font, 130)
+					heighttext = sizetext.Height
+					rb.Height = heighttext + 15
 					ybot = rb.Bottom
-					yrb = ybot + 5
+					yrb += heighttext + 10
 					rbcounter += 1
 				else:
 					pass
@@ -675,10 +679,17 @@ try:
 			version = str(dynamo.GetName().Version)[:3]		
 			dynPath = os.getenv('APPDATA')+"\\Dynamo\Dynamo Revit\\" + version 
 			root = et.parse(dynPath + "\DynamoSettings.xml").getroot()
+			logopaths = []
 			for child in root:
 				if child.tag == "CustomPackageFolders":
 					for path in child:
-						deflogopath = path.text + "\packages\Data-Shapes\extra\\a.png"
+						logopaths.append(path.text + "\packages\Data-Shapes\extra\\a.png")
+						logopaths.append(path.text + "\Data-Shapes\extra\\a.png")
+			deflogopath = ""
+			for path in logopaths:
+				if deflogopath == "":
+					if os.path.isfile(path):
+						deflogopath = path
 						try:
 							ima = Image.FromFile(deflogopath)
 							bmp = Bitmap.FromFile(deflogopath)
@@ -843,6 +854,6 @@ except:
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Background Preview" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+    <Camera Name="Hintergrundvorschau" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
   </Cameras>
 </Workspace>


### PR DESCRIPTION
This fixes the underlying issue of #13 - the missing logo.
When building your logo path you are assuming that the package directory from the ettings.xml has a subdirectory called "packages". In case of a custom package folder path this may not be the case.
It would still make sense to fix #13 as in some cases packages may be organized in other subfolders.