### PR TITLE
Removed default value for InputName in UI.Boolean Data

### DIFF
--- a/Nodes/UI.Boolean Data.dyf
+++ b/Nodes/UI.Boolean Data.dyf
@@ -28,7 +28,7 @@ OUT = x</Script>
       <Symbol value="Boolean input" />
     </Dynamo.Graph.Nodes.CustomNodes.Output>
     <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="0850cf62-9207-48fd-9266-3961b5312c85" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-93" y="-79" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
-      <Symbol value="InputName : string = &quot;Input&quot;" />
+      <Symbol value="InputName : string = &quot;&quot;" />
     </Dynamo.Graph.Nodes.CustomNodes.Symbol>
     <Dynamo.Graph.Nodes.CustomNodes.Symbol guid="80f9ebea-2f68-4bc1-9d7a-c23db66a6987" type="Dynamo.Graph.Nodes.CustomNodes.Symbol" nickname="Input" x="-82" y="16" isVisible="true" isUpstreamVisible="true" lacing="Disabled" isSelectedInput="True" IsFrozen="false" isPinned="false">
       <Symbol value="DefaultValue : bool = false" />
@@ -47,6 +47,6 @@ OUT = x</Script>
   <Annotations />
   <Presets />
   <Cameras>
-    <Camera Name="Aperçu en arrière-plan" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
+    <Camera Name="Hintergrundvorschau" eyeX="-17" eyeY="24" eyeZ="50" lookX="12" lookY="-13" lookZ="-58" upX="0" upY="1" upZ="0" />
   </Cameras>
 </Workspace>


### PR DESCRIPTION
Hi Mostafa,
since all other Ui nodes use an empty string as the default InputName, I thought it would make sense to do the same for the UI.Boolean Data node.
![grafik](https://user-images.githubusercontent.com/3014437/32799973-6eed2a7a-c979-11e7-8009-6df630afa5a2.png)
